### PR TITLE
support task def tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -465,6 +465,8 @@ resource "aws_ecs_task_definition" "main" {
       container_definitions,
     ]
   }
+
+  tags = var.task_definition_tags
 }
 
 # Create a data source to pull the latest active revision from

--- a/variables.tf
+++ b/variables.tf
@@ -251,3 +251,9 @@ variable "ecs_exec_enable" {
   default     = false
   type        = bool
 }
+
+variable "task_definition_tags" {
+  description = "Tags to apply to the task definition"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Now that we have branched this repo we can improve on it. This PR add the ability to tag the task definition. This will be used downstream by the ecs-microservice module to add the ReleaseID tag which is something the lean metrics system looks for. As of now the lean metrics system had fall back to `unknown` which disrupts the calculation of rollbacks/hotfixes