### PR TITLE
[GH actions] add reusable tag&release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Tag Release
+name: 🏷 Tag and release
 
 on:
   push:
@@ -11,10 +11,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: onemedical/action-general-autotag@1.1.0
+      - name: 📥 Check out code
+        uses: actions/checkout@v3
+
+      - name: 🏷 Create a tag
+        id: create-tag
+        uses: butlerlogic/action-autotag@stable
         with:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          source_file: 'version'
-          extraction_regex: "(\\d+\\.\\d+\\.\\d+)"
-          tag_format: 'v{version}'
+          strategy: regex
+          root: 'lib/crane/version.rb'
+          regex_pattern: "(\\d+\\.\\d+\\.\\d+)"
+          tag_prefix: "v"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: 🦄 Create a release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          tag: ${{ steps.create-tag.outputs.tagname }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Jira Ticket: [INFRA-3780](https://onemedical.atlassian.net/browse/INFRA-3780)

This PR is part of the effort to switch from outdated and not-supported [Jaliborc/action-general-autotag](https://github.com/Jaliborc/action-general-autotag) GH action which was forked in [onemedical/action-general-autotag](https://github.com/onemedical/action-general-autotag) and move to more supported GH action.

Not using reusable workflow here bc public repos can't use reusable workflows from private repos.

From official docs:
` Actions and reusable workflows stored in internal repositories cannot be used in public repositories and actions and reusable workflows stored in private repositories cannot be used in public or internal repositories.
`



[INFRA-3780]: https://onemedical.atlassian.net/browse/INFRA-3780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ