### PR TITLE
fix tag-and-release.yaml syntax to trigger github action tag-and-release on main branch

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -7,7 +7,8 @@ on:
   push:
     paths:
       - version
-    branches: [main, master]
+    branches:
+      - main
 
 
 permissions:


### PR DESCRIPTION
quick syntax fix in tag-and-release.yaml github workflow
